### PR TITLE
Remove unused argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ observer.observe(document.documentElement, {
 module.exports = function onload (node, onload, offload) {
   off = false
   node.classList.add(clz)
-  tracking.set(node, [ onload || noop, offload || noop, 2, 2 ])
+  tracking.set(node, [ onload || noop, offload || noop, 2 ])
   return node
 }
 


### PR DESCRIPTION
As pointed out by https://github.com/hyperdivision/fast-on-load/commit/d72da4ef6eaa4dd0d22278f3c084d6eeea237987#r33801544 this removes an used argument.