### PR TITLE
Make it work in non-dom context

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Returns the node itself.
 
 Pass in references to the `onload` and `onunload` functions and the node they are attached to to remove them from the function set that get run on load and unload.  Pass `undefined` for `onload` if you only attached and `onunload` function.
 
+`onload = onload.bind(dom.window)`
+
+To run in non-dom context, such as [jsdom](https://ghub.io/jsdom), call `onload` with desired `window` context.
+
 ## Install
 
 ```sh

--- a/index.js
+++ b/index.js
@@ -1,23 +1,17 @@
 const tracking = new WeakMap()
 const clz = 'onload-' + Math.random().toString(36).slice(2)
-const observer = new window.MutationObserver(onchange)
-
-const isConnected = 'isConnected' in window.Node.prototype
-  ? node => node.isConnected
-  : node => document.documentElement.contains(node)
-
-let off = true
-
-observer.observe(document.documentElement, {
-  childList: true,
-  subtree: true
-})
+const windows = new WeakSet()
 
 module.exports = onload
 function onload (node, onload, offload) {
-  off = false
   node.classList.add(clz)
-  const set = upsert(node)
+
+  if (!tracking.has(node)) {
+    tracking.set(node, new Set())
+    if (!windows.has(this)) create(this)
+  }
+  const set = tracking.get(node)
+
   set.add([ onload || noop, offload || noop, 2 ])
   return node
 }
@@ -34,49 +28,56 @@ onload.delete = function (node, onload = noop, offload = noop) {
   return false
 }
 
-function upsert (node) {
-  const set = tracking.get(node)
-  if (set) return set
-  const n = new Set()
-  tracking.set(node, n)
-  return n
-}
-
 function noop () { }
 
-function callAll (nodes, idx, target) {
-  for (let i = 0; i < nodes.length; i++) {
-    if (!nodes[i].classList) continue
-    if (nodes[i].classList.contains(clz)) call(nodes[i], idx, target)
-    const els = nodes[i].getElementsByClassName(clz)
-    for (let j = 0; j < els.length; j++) call(els[j], idx, target)
-  }
-}
+function create (window) {
+  windows.add(window)
 
-// State Enum
-// 0: mounted
-// 1: unmounted
-// 2: undefined
-function call (node, state, target) {
-  const set = tracking.get(node)
-  if (!set) return
-  for (const ls of set) {
-    if (ls[2] === state) continue
-    if (state === 0 && isConnected(node)) {
-      ls[2] = 0
-      ls[0](node, target)
-    } else if (state === 1 && !isConnected(node)) {
-      ls[2] = 1
-      ls[1](node, target)
+  const document = window.document
+  const observer = new window.MutationObserver(onchange)
+
+  const isConnected = 'isConnected' in window.Node.prototype
+    ? node => node.isConnected
+    : node => document.documentElement.contains(node)
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true
+  })
+
+  function callAll (nodes, idx, target) {
+    for (let i = 0; i < nodes.length; i++) {
+      if (!nodes[i].classList) continue
+      if (nodes[i].classList.contains(clz)) call(nodes[i], idx, target)
+      const els = nodes[i].getElementsByClassName(clz)
+      for (let j = 0; j < els.length; j++) call(els[j], idx, target)
     }
   }
-}
 
-function onchange (mutations) {
-  if (off) return
-  for (let i = 0; i < mutations.length; i++) {
-    const { addedNodes, removedNodes, target } = mutations[i]
-    callAll(removedNodes, 1, target)
-    callAll(addedNodes, 0, target)
+  // State Enum
+  // 0: mounted
+  // 1: unmounted
+  // 2: undefined
+  function call (node, state, target) {
+    const set = tracking.get(node)
+    if (!set) return
+    for (const ls of set) {
+      if (ls[2] === state) continue
+      if (state === 0 && isConnected(node)) {
+        ls[2] = 0
+        ls[0](node, target)
+      } else if (state === 1 && !isConnected(node)) {
+        ls[2] = 1
+        ls[1](node, target)
+      }
+    }
+  }
+
+  function onchange (mutations) {
+    for (let i = 0; i < mutations.length; i++) {
+      const { addedNodes, removedNodes, target } = mutations[i]
+      callAll(removedNodes, 1, target)
+      callAll(addedNodes, 0, target)
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {},
   "devDependencies": {
     "browserify": "^16.2.3",
+    "jsdom": "^15.1.1",
     "standard": "^12.0.1",
     "tape": "^4.10.1",
     "tape-run": "^6.0.0",

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 var onload = require('./')
 var test = require('tape')
 var yo = require('yo-yo')
+var JSDOM = require('jsdom').JSDOM
 
 test('onload/onunload', function (t) {
   t.plan(2)
@@ -237,6 +238,23 @@ test('onload.delete works', function (t) {
     t.fail('Unload function should not be called')
   }
   onload(el, loadFunction, unloadFunction)
+  document.body.appendChild(el)
+})
+
+test('external document', function (t) {
+  var dom = new JSDOM('<!doctype html>')
+  var window = dom.window
+  var document = window.document
+  var el = document.createElement('div')
+
+  onload.call(window, el, function () {
+    t.ok(true, 'onload called')
+    document.body.removeChild(el)
+  }, function () {
+    t.ok(true, 'onunload called')
+    document.body.innerHTML = ''
+    t.end()
+  })
   document.body.appendChild(el)
 })
 


### PR DESCRIPTION
This fixes #6, introduces minimal necessary change to support non-dom contexts.

Now it does not block nodejs env. Should not affect performance.

- observer takes lazy-init strategy
- `off` is not required anymore
- `isConnected` is dependent on window target

cc @bcomnes 